### PR TITLE
🪲 BUG: Fix mysql+pymysql scheme not supported by dj_database_url

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+import pymysql
+
+pymysql.install_as_MySQLdb()

--- a/app/settings/development.py
+++ b/app/settings/development.py
@@ -7,6 +7,8 @@ from django.utils.translation import gettext_lazy as _
 
 warnings.simplefilter('error', DeprecationWarning)
 
+url.SCHEMES['mysql+pymysql'] = 'django.db.backends.mysql'
+
 BASE_DIR = dirname(dirname(dirname(os.path.abspath(__file__))))
 CONTENT_DIR = os.path.join(BASE_DIR, 'content')
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/app/settings/production.py
+++ b/app/settings/production.py
@@ -4,6 +4,8 @@ import dj_database_url as url
 from os.path import dirname
 from django.utils.translation import gettext_lazy as _
 
+url.SCHEMES['mysql+pymysql'] = 'django.db.backends.mysql'
+
 BASE_DIR = dirname(dirname(dirname(os.path.abspath(__file__))))
 CONTENT_DIR = os.path.join(BASE_DIR, 'content')
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
## Summary
- `.env-default` (since commit 3764641) ships `DJANGO_DATABASE_URL=mysql+pymysql://...`, a scheme `dj_database_url` never supported → crashes on startup with `ValueError: No support for 'mysql+pymysql'`
- Registered `mysql+pymysql` in `dj_database_url.SCHEMES` (development.py, production.py)
- Added `pymysql.install_as_MySQLdb()` shim in `app/__init__.py` — required because Django's `mysql` backend imports `MySQLdb`, and the project only ships `pymysql`, not `mysqlclient`

## Test plan
- [x] With `DJANGO_DATABASE_URL=mysql+pymysql://...` set, `django.setup()` resolves `ENGINE=django.db.backends.mysql` without error
- [x] With no `DJANGO_DATABASE_URL`, sqlite fallback still works unaffected